### PR TITLE
HuggingFace integration 

### DIFF
--- a/src/styletts2/Utils/PLBERT/util.py
+++ b/src/styletts2/Utils/PLBERT/util.py
@@ -50,3 +50,14 @@ def load_plbert(log_dir, config_path=None, checkpoint_path=None):
     bert.load_state_dict(new_state_dict, strict=False)
     
     return bert
+
+def load_plbert_v2(plbert_config):
+    """
+    * load_config
+    * load_weights
+    * weights_manipulation
+    """
+    albert_base_configuration = AlbertConfig(**plbert_config['model_params'])
+    bert = CustomAlbert(albert_base_configuration)
+    return bert
+    

--- a/src/styletts2/Utils/PLBERT/util.py
+++ b/src/styletts2/Utils/PLBERT/util.py
@@ -52,11 +52,6 @@ def load_plbert(log_dir, config_path=None, checkpoint_path=None):
     return bert
 
 def load_plbert_v2(plbert_config):
-    """
-    * load_config
-    * load_weights
-    * weights_manipulation
-    """
     albert_base_configuration = AlbertConfig(**plbert_config['model_params'])
     bert = CustomAlbert(albert_base_configuration)
     return bert

--- a/src/styletts2/models.py
+++ b/src/styletts2/models.py
@@ -591,6 +591,16 @@ def load_F0_models(path):
     
     return F0_model
 
+def load_F0_models_v2():
+    """
+    * load_checkpoint
+    """
+    F0_model = JDCNet(num_class=1, seq_len=192)
+    _ = F0_model.train()
+    
+    return F0_model
+
+
 def load_ASR_models(ASR_MODEL_PATH, ASR_MODEL_CONFIG):
     # load ASR model
     def _load_config(path):
@@ -610,6 +620,23 @@ def load_ASR_models(ASR_MODEL_PATH, ASR_MODEL_CONFIG):
     _ = asr_model.train()
 
     return asr_model
+
+def load_ASR_models_v2(ASR_MODEL_CONFIG):
+    """"
+    * config 
+    * custom model path
+    """
+    def _load_model(model_config):
+        model = ASRCNN(**model_config)
+        return model
+
+    asr_model_config = ASR_MODEL_CONFIG['model_params']
+    asr_model = _load_model(asr_model_config)
+    
+    _ = asr_model.train()
+
+    return asr_model
+
 
 def build_model(args, text_aligner, pitch_extractor, bert):
     assert args.decoder.type in ['istftnet', 'hifigan'], 'Decoder type unknown'

--- a/src/styletts2/models.py
+++ b/src/styletts2/models.py
@@ -592,9 +592,6 @@ def load_F0_models(path):
     return F0_model
 
 def load_F0_models_v2():
-    """
-    * load_checkpoint
-    """
     F0_model = JDCNet(num_class=1, seq_len=192)
     _ = F0_model.train()
     
@@ -622,10 +619,6 @@ def load_ASR_models(ASR_MODEL_PATH, ASR_MODEL_CONFIG):
     return asr_model
 
 def load_ASR_models_v2(ASR_MODEL_CONFIG):
-    """"
-    * config 
-    * custom model path
-    """
     def _load_model(model_config):
         model = ASRCNN(**model_config)
         return model

--- a/src/styletts2/tts.py
+++ b/src/styletts2/tts.py
@@ -180,8 +180,6 @@ class StyleTTS2(
         * weights_manipulation
         """
         self.config  = LIBRI_TTS_CONFIG
-        # either present or passed as parameter
-        ASR_config = self.config.get('ASR_config', ASR_config)
         # saving them in self for easier access later when updating the weights
         self.text_aligner = models.load_ASR_models_v2(ASR_config)
         self.pitch_extractor = models.load_F0_models_v2() 

--- a/src/styletts2/tts.py
+++ b/src/styletts2/tts.py
@@ -176,11 +176,6 @@ class StyleTTS2(
         return model
     
     def load_model_v2(self,LIBRI_TTS_CONFIG,ASR_config,plbert_config):
-        """
-        * load_config
-        * load_checkpoint 
-        * weights_manipulation
-        """
         self.config  = LIBRI_TTS_CONFIG
         # saving them in self for easier access later when updating the weights
         self.text_aligner = models.load_ASR_models_v2(ASR_config)

--- a/src/styletts2/tts.py
+++ b/src/styletts2/tts.py
@@ -74,6 +74,7 @@ def segment_text(text):
 
 
 class StyleTTS2(
+    torch.nn.Module,
     PyTorchModelHubMixin,
     library_name="styletts2",
     repo_url="https://github.com/korakoe/StyleTTS2lib.git",

--- a/src/styletts2/tts.py
+++ b/src/styletts2/tts.py
@@ -77,7 +77,7 @@ class StyleTTS2(
     PyTorchModelHubMixin,
     library_name="styletts2",
     repo_url="https://github.com/korakoe/StyleTTS2lib.git",
-    tags="text-to-speech"
+    tags=["text-to-speech"]
     ):
     # def __init__(self, model_checkpoint_path=None, config_path=None, phoneme_converter='gruut'):
     def __init__(self, model_checkpoint_path=None, config_path=None, phoneme_converter='gruut',LIBRI_TTS_CONFIG=None,ASR_config=None,BERT_CONFIG=None):

--- a/src/styletts2/tts.py
+++ b/src/styletts2/tts.py
@@ -82,6 +82,7 @@ class StyleTTS2(
     ):
     # def __init__(self, model_checkpoint_path=None, config_path=None, phoneme_converter='gruut'):
     def __init__(self, model_checkpoint_path=None, config_path=None, phoneme_converter='gruut',LIBRI_TTS_CONFIG=None,ASR_config=None,BERT_CONFIG=None):
+        super(StyleTTS2, self).__init__()
         self.model = None
         self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
         self.phoneme_converter = PhonemeConverterFactory.load_phoneme_converter(phoneme_converter)


### PR DESCRIPTION
Hi ButterCream

As discussed in discord, this pr will improve the huggingface integration.

To effectively migrate your previous implementation to huggingface,  I have made this colab notebook on how to do it in here: https://colab.research.google.com/drive/13d8oR3LgwguIXGbcVHIKy3C23QsnTNpf?usp=sharing (first-time use only) 

Once you have updated your repo using this update all users can access the following methods : 
* save_pretrained
* push_to_hub
* from_pretrained 

By using PyTorchModelHub you can get access to : 
* know how many times your model has been downloaded from huggingface each month 
* filter huggingface and check how many styletts2 models exist on the hub


Allowing users to load Vokan checkpoints with ease (and possibly finetune and store their finetuned versions too).

## Notes : 
* for backward compatibility I have made my loading script independent from yours to avoid breaking other people's codes.
* I couldn't update `huggingface_hub` dependency and poetry was a bit hard to work with, so please update it to the latest version if possible. ⚠️
* Recommended: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "styletts2" official on the Hub meaning better discoverability + possibility to add code snippets. 

If you have any questions or feedback feel free to reach out either in this pr or in discord.

Regards
* Hafedh Hichri (Lain)
